### PR TITLE
Simple comparison of strings is not sufficient

### DIFF
--- a/merge_requirements/manage_file.py
+++ b/merge_requirements/manage_file.py
@@ -64,7 +64,7 @@ class Merge(object):
 
     def merge_dict_libs(self):
 
-        self.dict_libs = merge_dict(
+        (self.dict_libs, self.error_count) = merge_dict(
             self.manage_file.first_file,
             self.manage_file.second_file
         )
@@ -94,3 +94,6 @@ class Merge(object):
         f.close()
 
         print('create new file {}'.format(file_path))
+        if self.error_count > 0:
+            print('WARN: {} values failed to merge.'.format(self.error_count), file=sys.stderr)
+            sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+packaging==17.1
+pyparsing==2.2.0
+six==1.11.0

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     description='simple lib for organize two requirements.txt in a unique requirements.txt file',
     packages=['merge_requirements'],
     scripts=['scripts/merge_requirements'],
+    install_requires=['packaging'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
* Version comparison not used so `2.9.6` would be chosen in preference to `2.10`
* `merge_dict()` didn't handle base_dict having keys not found in m_dict
  * not clear if this was intentional, but this makes this far more flexible

This does not resolve any dependencies of the form `git+git://github.com/....` but they continue to be populated through to the final file.